### PR TITLE
Add max(0, ...) to garage command

### DIFF
--- a/source/plugins/garage_status.py
+++ b/source/plugins/garage_status.py
@@ -41,7 +41,7 @@ class Garage:
 
     def set_saturated_space(self, available_space):
         """Set the saturated space."""
-        self.saturated_space = self.capacity - int(available_space)
+        self.saturated_space = max(self.capacity - int(available_space), 0)
         self.percent_full = self.__get_percent_full()
 
 


### PR DESCRIPTION
Previously the garage plugin was returning negative saturations when saturation was low.