### PR TITLE
Added new !calendar command.

### DIFF
--- a/source/plugins/__init__.py
+++ b/source/plugins/__init__.py
@@ -7,6 +7,7 @@ Written by Tiger Sachse.
 """
 
 from plugins import (
+    calendar,
     egg,
     dog,
     info,
@@ -28,6 +29,7 @@ FILTERED_CHANNELS = {
 }
 
 COMMANDS = {
+    calendar.COMMAND : calendar.command_calendar,
     egg.COMMAND : egg.command_egg,
     dog.COMMAND : dog.command_dog,
     info.COMMAND : info.command_info,

--- a/source/plugins/calendar.py
+++ b/source/plugins/calendar.py
@@ -1,0 +1,56 @@
+"""Displays the current academic calendar information.
+
+Written by eezstreet
+"""
+
+import discord
+import re
+import requests
+from datetime import datetime
+
+COMMAND = "calendar"
+DEFAULT_TERM = "spring"
+DEFAULT_YEAR = 2019
+SYNTAX = "^!calendar ?(?P<term>[A-Za-z]+)? ?(?P<year>[0-9]+)? ?(?P<filter>[A-Za-z-_]+)?"
+EMBED_COLOR = 0xFFFF00
+
+async def fetch_calendar(term, year):
+    """Fetch the calendar information for the given term and semester"""
+    url = "http://calendar.ucf.edu/json/{}/{}".format(year, term)
+    r = requests.get(url)
+    return r.json()
+
+async def command_calendar(client, message):
+    """Show the academic calendar"""
+    command_match = re.match(SYNTAX, message.content)
+
+    if command_match is None:
+        response = "Incorrect command syntax. Try `!help`."
+        await message.channel.send(response)
+        return
+
+    term = command_match.group("term")
+    if term is None:
+        term = DEFAULT_TERM
+
+    year = command_match.group("year")
+    if year is None:
+        year = DEFAULT_YEAR
+
+    calendar_data = await fetch_calendar(term, year)
+    if calendar_data['terms'] is None:
+        await message.channel.send("Could not find data for that term.")
+        return
+    embed = generate_embed(calendar_data, command_match.group("filter"))
+
+    await message.channel.send("", embed=embed)
+
+
+def generate_embed(calendar_data, tags):
+    embed = discord.Embed(color=EMBED_COLOR)
+    
+    term = calendar_data['terms'][0]
+    for event in term['events']:
+        if tags is None or event['tags'] is not None and tags in event['tags']:
+            embed.add_field(name=event['category'], value=event['summary'], inline=False)
+    return embed

--- a/source/plugins/calendar.py
+++ b/source/plugins/calendar.py
@@ -13,6 +13,7 @@ DEFAULT_TERM = "spring"
 DEFAULT_YEAR = 2019
 SYNTAX = "^!calendar ?(?P<term>[A-Za-z]+)? ?(?P<year>[0-9]+)? ?(?P<filter>[A-Za-z-_]+)?"
 EMBED_COLOR = 0xFFFF00
+SYNTAX_HELP = "Could not find data for that term. Try `!help` for syntax help."
 
 async def fetch_calendar(term, year):
     """Fetch the calendar information for the given term and semester"""
@@ -25,7 +26,7 @@ async def command_calendar(client, message):
     command_match = re.match(SYNTAX, message.content)
 
     if command_match is None:
-        response = "Incorrect command syntax. Try `!help`."
+        response = SYNTAX_HELP
         await message.channel.send(response)
         return
 
@@ -37,20 +38,38 @@ async def command_calendar(client, message):
     if year is None:
         year = DEFAULT_YEAR
 
-    calendar_data = await fetch_calendar(term, year)
-    if calendar_data['terms'] is None:
-        await message.channel.send("Could not find data for that term.")
-        return
-    embed = generate_embed(calendar_data, command_match.group("filter"))
+    try:
+        calendar_data = await fetch_calendar(term, year)
+        if calendar_data['terms'] is None:
+            await message.channel.send(SYNTAX_HELP)
+            return
+        embed = generate_embed(calendar_data, command_match.group("filter"))
 
-    await message.channel.send("", embed=embed)
+        await message.channel.send("", embed=embed)
+    except ValueError:
+        await message.channel.send(SYNTAX_HELP)
 
+def format_time(timestr):
+    time = datetime.strptime(timestr, '%Y-%m-%d %H:%M:%SZ')
+    
+    if time.hour is 0:
+        return time.strftime('%B %e')
+    return time.strftime('%b %e at %I:%M%p')
 
 def generate_embed(calendar_data, tags):
     embed = discord.Embed(color=EMBED_COLOR)
     
     term = calendar_data['terms'][0]
     for event in term['events']:
+        title = event['summary']
+
+        if tags is None and event['tags'] is not None:
+            title = "{} ({})".format(event['summary'], event['tags'][0])
+
         if tags is None or event['tags'] is not None and tags in event['tags']:
-            embed.add_field(name=event['category'], value=event['summary'], inline=False)
+            if event['dtend'] is None or event['dtend'] is '':
+                """There is no ending date to be considered."""
+                embed.add_field(name=title, value=format_time(event['dtstart']), inline=False)
+            else:
+                embed.add_field(name=title, value="{} to {}".format(format_time(event['dtstart']), format_time(event['dtend'])), inline=False)
     return embed

--- a/source/plugins/help_menu.py
+++ b/source/plugins/help_menu.py
@@ -76,6 +76,12 @@ async def command_help_menu(client, message):
         value="Send your text through the egg machine.",
         inline=False
     )
+
+    embedded_message.add_field(
+        name="!calendar <spring/summer/fall> <year> [tag filter]",
+        value="View the academic calendar. Common tags include no-classes, registration, housing, undergraduate, graduate, and faculty.",
+        inline=False
+    )
     
     embedded_message.add_field(
         name="!weather [city|zip]",


### PR DESCRIPTION
This command lets you view the academic calendar for the given term and year. It defaults to Spring 2019 if no term is given, and alerts the user if an invalid term and year are given.

For example:
`!calendar Fall 2019` will return all events which occur for the Fall 2019 semester and when they happen. Though, this is cut off since Discord embeds can only be so long.
`!calendar Fall 2019 housing` will return all events pertaining to housing.
`!calendar Fall 2019 no-classes` will return all of the times where there is no school (incl. Thanksgiving, Christmas, etc)

There's a lot of different tags, I've listed a few in the !help command. You can see the raw JSON data that it is parsing from [here.](https://calendar.ucf.edu/json/2018/fall)